### PR TITLE
내상점 - 내 정보 조회

### DIFF
--- a/src/apis/AxiosClient.ts
+++ b/src/apis/AxiosClient.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+import { BASE_URI } from '@/constants/URI.ts';
+
+export const axiosClient = axios.create({
+  baseURL: BASE_URI,
+  headers: {
+    /**
+     *  Content-Type: 현재 전송하는 데이터의 타입을 설명
+     *  application/json: JSON 형태로 데이터를 전송
+     * */
+    'Content-Type': 'application/json',
+  },
+});
+
+axiosClient.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('accessToken');
+    if (token) {
+      config.headers['Authorization'] = token;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);

--- a/src/apis/OAuth.ts
+++ b/src/apis/OAuth.ts
@@ -1,4 +1,0 @@
-// hooks/useOauth2Redirect.js
-import { REDIRECT_URI, REST_API_KEY } from '@/constants/URI';
-
-export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;

--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -5,9 +5,10 @@ import axios from 'axios';
 
 import { BASE_URI } from '@/constants/URI.ts';
 
-export const useOauth2Redirect = (code: string | null) => {
+export const authApi = (code: string | null) => {
   const navigate = useNavigate();
 
+  // 인가코드 받아서 토큰 요청
   useEffect(() => {
     if (code) {
       axios
@@ -18,13 +19,14 @@ export const useOauth2Redirect = (code: string | null) => {
           const accessToken = res.headers.authorization;
           console.log(accessToken);
 
-          // Save the token to localStorage
+          // 로컬 스토리지에 토큰 저장
           localStorage.setItem('accessToken', accessToken);
 
-          navigate('/nickname');
+          navigate(-2);
         })
         .catch((error) => {
           console.error('Error during OAuth2 redirect:', error);
+          // logOut();
         });
     }
   }, [code, navigate]);

--- a/src/apis/shop/shop.api.ts
+++ b/src/apis/shop/shop.api.ts
@@ -1,0 +1,9 @@
+import { axiosClient } from '@/apis/AxiosClient.ts';
+import { MyInfoResponse } from '@/apis/shop/shop.response.ts';
+
+// import { MyInfoResponse } from '@/apis/shop/shop.response.ts';
+
+export async function myInfo(): Promise<MyInfoResponse> {
+  const myData = await axiosClient.get('/api/user');
+  return myData.data;
+}

--- a/src/apis/shop/shop.api.ts
+++ b/src/apis/shop/shop.api.ts
@@ -1,4 +1,5 @@
 import { axiosClient } from '@/apis/AxiosClient.ts';
+import { FixNickNameRequest } from '@/apis/shop/shop.request.ts';
 import { MyInfoResponse } from '@/apis/shop/shop.response.ts';
 
 // import { MyInfoResponse } from '@/apis/shop/shop.response.ts';
@@ -6,4 +7,13 @@ import { MyInfoResponse } from '@/apis/shop/shop.response.ts';
 export async function myInfo(): Promise<MyInfoResponse> {
   const myData = await axiosClient.get('/api/user');
   return myData.data;
+}
+
+export async function FixNickName(
+  request: FixNickNameRequest
+): Promise<string> {
+  const reNickName = await axiosClient.put('/api/user', {
+    ...request,
+  });
+  return reNickName.data;
 }

--- a/src/apis/shop/shop.request.ts
+++ b/src/apis/shop/shop.request.ts
@@ -1,0 +1,3 @@
+export interface FixNickNameRequest {
+  nickname: string;
+}

--- a/src/apis/shop/shop.response.ts
+++ b/src/apis/shop/shop.response.ts
@@ -1,6 +1,6 @@
 export interface MyInfoResponse {
-  id: number;
+  userId: number;
   nickname: string;
   email: string;
-  userName: string;
+  username: string;
 }

--- a/src/apis/shop/shop.response.ts
+++ b/src/apis/shop/shop.response.ts
@@ -1,0 +1,6 @@
+export interface MyInfoResponse {
+  id: number;
+  nickname: string;
+  email: string;
+  userName: string;
+}

--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -53,7 +53,7 @@ export const MenuWrapper = styled.li`
     //margin: 0 1rem;
     margin: auto;
   }
-  &:first-child:before {
+  &:first-of-type:before {
     display: none;
   }
 `;

--- a/src/constants/URI.ts
+++ b/src/constants/URI.ts
@@ -2,3 +2,5 @@ export const BASE_URI = import.meta.env.VITE_APP_BASE_URL;
 
 export const REST_API_KEY = import.meta.env.VITE_APP_REST_API_KEY;
 export const REDIRECT_URI = import.meta.env.VITE_APP_REDIRECT_URI;
+
+export const KAKAO_AUTH_URL: string = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;

--- a/src/pages/login/RedirectPage.tsx
+++ b/src/pages/login/RedirectPage.tsx
@@ -1,5 +1,5 @@
 import { BASE_URI } from '@/constants/URI.ts';
-import { useOauth2Redirect } from '@/hooks/useOauth2Redirect.ts';
+import { authApi } from '@/apis/auth/auth.api.ts';
 
 export const RedirectPage = () => {
   const CODE: string | null = new URLSearchParams(window.location.search).get(
@@ -7,7 +7,7 @@ export const RedirectPage = () => {
   );
   console.log(`${BASE_URI}/oauth2?code=${CODE}`);
 
-  useOauth2Redirect(CODE);
+  authApi(CODE);
 
   return (
     <>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,6 +1,6 @@
 import * as Styles from './styles';
-import { KAKAO_AUTH_URL } from '@/apis/OAuth';
 import Logo from '@/assets/kakao.svg';
+import { KAKAO_AUTH_URL } from '@/constants/URI';
 
 const LoginPage = () => {
   const HandlerKakaoLogin = () => {

--- a/src/pages/shop/components/EmailSection.tsx
+++ b/src/pages/shop/components/EmailSection.tsx
@@ -1,14 +1,17 @@
 import * as Styles from '../styles';
 import kakaoLogo from '@/assets/kakao.svg';
+import { EmailSectionProps } from '@/pages/shop/type';
 
-export const EmailSection = () => {
+export const EmailSection: React.FC<EmailSectionProps> = ({
+  email,
+}: EmailSectionProps) => {
   return (
     <Styles.EmailContainer>
       <Styles.KakaoContainer>
         <Styles.KakaoSymbol src={kakaoLogo} />
         Kakao
       </Styles.KakaoContainer>
-      <Styles.EmailItem>user1234@kakao.com</Styles.EmailItem>
+      <Styles.EmailItem>{email}</Styles.EmailItem>
     </Styles.EmailContainer>
   );
 };

--- a/src/pages/shop/components/NickNameSection.tsx
+++ b/src/pages/shop/components/NickNameSection.tsx
@@ -1,9 +1,10 @@
 import * as Styles from '../styles.ts';
+import { NicknameSectionProps } from '@/pages/shop/type.ts';
 
-export const NicknameSection = () => {
+export const NicknameSection:React.FC<NicknameSectionProps> = ({ nickname }) => {
   return (
     <Styles.InfoContainer>
-      <Styles.NicknameItem>User 1234</Styles.NicknameItem>
+      <Styles.NicknameItem>{nickname}</Styles.NicknameItem>
       <Styles.NicknameEdit>닉네임 수정</Styles.NicknameEdit>
     </Styles.InfoContainer>
   );

--- a/src/pages/shop/components/NickNameSection.tsx
+++ b/src/pages/shop/components/NickNameSection.tsx
@@ -1,11 +1,43 @@
-import * as Styles from '../styles.ts';
-import { NicknameSectionProps } from '@/pages/shop/type.ts';
+import { useEffect, useState } from 'react';
 
-export const NicknameSection:React.FC<NicknameSectionProps> = ({ nickname }) => {
+import * as Styles from '../styles.ts';
+import { FixNickName, myInfo } from '@/apis/shop/shop.api';
+import { NicknameSectionProps } from '@/pages/shop/type.ts';
+import { useUserInfoStore } from '@/store/useUserInfoStore.ts';
+
+export const NicknameSection: React.FC<NicknameSectionProps> = ({
+  nickname,
+}) => {
+  const [newNickname, setNewNickname] = useState<string>(nickname);
+  console.log('nicknameSection:', nickname);
+
+  // console.log('nicknameSection out:', nickname);
+  const HandlerNickname = async () => {
+    const reNickName: string | null = prompt('변경할 닉네임을 입력해주세요');
+    console.log(reNickName);
+
+
+    if (reNickName) {
+      try {
+        const request = { nickname: reNickName };
+        const data = await FixNickName(request);
+        // setNewNickName(data);
+        console.log(data);
+        alert(`닉네임을 ${reNickName}(으)로 변경하였습니다!`);
+        setNewNickname(reNickName);
+      } catch (error) {
+        alert('닉네임 변경에 실패했습니다.');
+        console.error('유저 정보 받아오기 실패 :', error);
+      }
+    }
+  };
+
   return (
     <Styles.InfoContainer>
       <Styles.NicknameItem>{nickname}</Styles.NicknameItem>
-      <Styles.NicknameEdit>닉네임 수정</Styles.NicknameEdit>
+      <Styles.NicknameEdit onClick={HandlerNickname}>
+        닉네임 수정
+      </Styles.NicknameEdit>
     </Styles.InfoContainer>
   );
 };

--- a/src/pages/shop/components/UserInfoContainer.tsx
+++ b/src/pages/shop/components/UserInfoContainer.tsx
@@ -1,15 +1,56 @@
+import { useEffect } from 'react';
+
 import * as Styles from '../styles.ts';
 import { EmailSection } from './EmailSection';
 import { NicknameSection } from './NickNameSection';
+import { myInfo } from '@/apis/shop/shop.api.ts';
 import { UserInfoContainerProps } from '@/pages/shop/type';
+import { useUserInfoStore } from '@/store/useUserInfoStore.ts';
 
-export const UserInfoContainer: React.FC<UserInfoContainerProps> = ({
-  userInfo,
-}) => {
+export const UserInfoContainer: React.FC<UserInfoContainerProps> = () => {
+  // const { userId, nickname, email, username } = useUserInfoStore();
+  // console.log(userId, nickname, email, username);
+  const {
+    setUserId,
+    setNickname,
+    setEmail,
+    setUsername,
+    nickname,
+    userId,
+    username,
+    email,
+  } = useUserInfoStore();
+  //
+  //
+  useEffect(() => {
+    const fetchMyInfo = async () => {
+      try {
+        const data = await myInfo();
+
+        console.log(
+          'container.tsx: ',
+          data.userId,
+          data.nickname,
+          data.email,
+          data.username
+        );
+        setUserId(data.userId);
+        setNickname(data.nickname);
+        setEmail(data.email);
+        setUsername(data.username);
+      } catch (error) {
+        console.error('유저 정보 받아오기 실패 :', error);
+      }
+    };
+
+    fetchMyInfo();
+  }, []);
+
+  console.log('container', nickname, userId, email, username);
   return (
     <Styles.UserInfoContainer>
-      <NicknameSection nickname={userInfo.nickname} />
-      <EmailSection email={userInfo.email} />
+      <NicknameSection nickname={nickname} />
+      <EmailSection email={email} />
     </Styles.UserInfoContainer>
   );
 };

--- a/src/pages/shop/components/UserInfoContainer.tsx
+++ b/src/pages/shop/components/UserInfoContainer.tsx
@@ -1,12 +1,15 @@
 import * as Styles from '../styles.ts';
 import { EmailSection } from './EmailSection';
 import { NicknameSection } from './NickNameSection';
+import { UserInfoContainerProps } from '@/pages/shop/type';
 
-export const UserInfoContainer = () => {
+export const UserInfoContainer: React.FC<UserInfoContainerProps> = ({
+  userInfo,
+}) => {
   return (
     <Styles.UserInfoContainer>
-      <NicknameSection />
-      <EmailSection />
+      <NicknameSection nickname={userInfo.nickname} />
+      <EmailSection email={userInfo.email} />
     </Styles.UserInfoContainer>
   );
 };

--- a/src/pages/shop/components/UserInfoLayout.tsx
+++ b/src/pages/shop/components/UserInfoLayout.tsx
@@ -4,12 +4,13 @@ import { UserInfoLayoutProps } from '@/pages/shop/type.ts';
 
 export const UserInfoLayout: React.FC<UserInfoLayoutProps> = ({
   shopImg,
-  userInfo,
+  // userInfo,
 }) => {
   return (
     <Styles.UserInfoLayout>
       <Styles.UserImg src={shopImg} />
-      <UserInfoContainer userInfo={userInfo} />
+      {/*<UserInfoContainer userInfo={userInfo} />*/}
+      <UserInfoContainer />
     </Styles.UserInfoLayout>
   );
 };

--- a/src/pages/shop/components/UserInfoLayout.tsx
+++ b/src/pages/shop/components/UserInfoLayout.tsx
@@ -2,11 +2,14 @@ import * as Styles from '../styles.ts';
 import { UserInfoContainer } from './UserInfoContainer.tsx';
 import { UserInfoLayoutProps } from '@/pages/shop/type.ts';
 
-export const UserInfoLayout: React.FC<UserInfoLayoutProps> = ({ shopImg }) => {
+export const UserInfoLayout: React.FC<UserInfoLayoutProps> = ({
+  shopImg,
+  userInfo,
+}) => {
   return (
     <Styles.UserInfoLayout>
       <Styles.UserImg src={shopImg} />
-      <UserInfoContainer />
+      <UserInfoContainer userInfo={userInfo} />
     </Styles.UserInfoLayout>
   );
 };

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -1,37 +1,60 @@
-import { useState, useEffect } from 'react';
+// import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { TitleContainer } from './components/TitleContainer.tsx';
 import { UserInfoLayout } from './components/UserInfoLayout.tsx';
 import * as Styles from './styles';
 import { myInfo } from '@/apis/shop/shop.api.ts';
 import shopImg from '@/assets/Shop.png';
-import { UserInfo } from '@/pages/shop/type';
+// import { UserInfo } from '@/pages/shop/type';
+import { useUserInfoStore } from '@/store/useUserInfoStore';
 
 export const ShopPage: React.FC = () => {
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  // const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  //
+  // const { userId, nickname, email, username } = useUserInfoStore<UserInfoState>(
+  //   (state) => state
+  // );
+  // const { setUserId, setNickname, setEmail, setUsername } = useUserInfoStore();
+  // //
+  // //
+  // useEffect(() => {
+  //   const fetchMyInfo = async () => {
+  //     try {
+  //       const data = await myInfo();
+  //
+  //       console.log(
+  //         'index.tsx: ',
+  //         data.userId,
+  //         data.nickname,
+  //         data.email,
+  //         data.username
+  //       );
+  //       setUserId(data.userId);
+  //       setNickname(data.nickname);
+  //       setEmail(data.email);
+  //       setUsername(data.username);
+  //     } catch (error) {
+  //       console.error('유저 정보 받아오기 실패 :', error);
+  //     }
+  //   };
+  //
+  //   fetchMyInfo();
+  // }, []);
 
-  useEffect(() => {
-    const fetchMyInfo = async () => {
-      try {
-        const data = await myInfo();
-        setUserInfo(data);
-      } catch (error) {
-        console.error('유저 정보 받아오기 실패 :', error);
-      }
-    };
-
-    fetchMyInfo();
-  }, []);
-
-  if (!userInfo) {
-    return <div>loading...</div>;
-  }
+  // if (!userInfo) {
+  //   return <div>loading...</div>;
+  // }
+  // console.log(userInfo);
 
   // const { nickname, email } = userInfo;
   return (
     <Styles.ShopLayout>
       <TitleContainer />
-      <UserInfoLayout shopImg={shopImg} userInfo={userInfo} />
+      <UserInfoLayout
+        shopImg={shopImg}
+        // userInfo={userInfo}
+      />
     </Styles.ShopLayout>
   );
 };

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -1,13 +1,37 @@
+import { useState, useEffect } from 'react';
+
 import { TitleContainer } from './components/TitleContainer.tsx';
 import { UserInfoLayout } from './components/UserInfoLayout.tsx';
 import * as Styles from './styles';
+import { myInfo } from '@/apis/shop/shop.api.ts';
 import shopImg from '@/assets/Shop.png';
+import { UserInfo } from '@/pages/shop/type';
 
-export const ShopPage = () => {
+export const ShopPage: React.FC = () => {
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    const fetchMyInfo = async () => {
+      try {
+        const data = await myInfo();
+        setUserInfo(data);
+      } catch (error) {
+        console.error('유저 정보 받아오기 실패 :', error);
+      }
+    };
+
+    fetchMyInfo();
+  }, []);
+
+  if (!userInfo) {
+    return <div>loading...</div>;
+  }
+
+  // const { nickname, email } = userInfo;
   return (
     <Styles.ShopLayout>
       <TitleContainer />
-      <UserInfoLayout shopImg={shopImg} />
+      <UserInfoLayout shopImg={shopImg} userInfo={userInfo} />
     </Styles.ShopLayout>
   );
 };

--- a/src/pages/shop/type.ts
+++ b/src/pages/shop/type.ts
@@ -1,14 +1,14 @@
 export interface UserInfoLayoutProps {
   shopImg: string;
   nickname?: string;
-  userInfo: UserInfo;
+  // userInfo: UserInfo;
 }
 
 export interface UserInfo {
-  id: number;
+  userId: number;
   nickname: string;
   email: string;
-  userName: string;
+  username: string;
 }
 
 export interface NicknameSectionProps {
@@ -20,6 +20,6 @@ export interface EmailSectionProps {
 }
 
 export interface UserInfoContainerProps {
-  nickname?: string | undefined;
-  userInfo: UserInfo;
+  nickname?: string;
+  // userInfo: UserInfo;
 }

--- a/src/pages/shop/type.ts
+++ b/src/pages/shop/type.ts
@@ -1,3 +1,25 @@
 export interface UserInfoLayoutProps {
   shopImg: string;
+  nickname?: string;
+  userInfo: UserInfo;
+}
+
+export interface UserInfo {
+  id: number;
+  nickname: string;
+  email: string;
+  userName: string;
+}
+
+export interface NicknameSectionProps {
+  nickname: string;
+}
+
+export interface EmailSectionProps {
+  email?: string;
+}
+
+export interface UserInfoContainerProps {
+  nickname?: string | undefined;
+  userInfo: UserInfo;
 }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -5,7 +5,7 @@ export interface AuthState {
   setAccessToken: (token: string) => void;
   logOut: () => void;
 }
-export const useStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set) => ({
   // access Token
   accessToken: '',
 

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,9 +1,18 @@
-import create from 'zustand';
+import { create } from 'zustand';
 
-interface AuthStore {
-  token?: string;
+export interface AuthState {
+  accessToken: string;
+  setAccessToken: (token: string) => void;
+  logOut: () => void;
 }
+export const useStore = create<AuthState>((set) => ({
+  // access Token
+  accessToken: '',
 
-export const useAuthStore = create<AuthStore>((set) => ({
-  token: localStorage.getItem('accessToken'),
+  // access Token 저장
+  setAccessToken: (token: string) => set({ accessToken: token }),
+
+  // 로그아웃
+  logOut: () => set({ accessToken: '' }),
 }));
+

--- a/src/store/useUserInfoStore.ts
+++ b/src/store/useUserInfoStore.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+
+interface UserInfoState {
+  userId: number;
+  setUserId: (userId: number) => void;
+  nickname: string;
+  setNickname: (nickname: string) => void;
+  email: string;
+  setEmail: (email: string) => void;
+  username: string;
+  setUsername: (username: string) => void;
+}
+
+export const useUserInfoStore = create<UserInfoState>((set) => ({
+  userId: 0,
+  nickname: 'nickname',
+  email: 'email',
+  username: 'username',
+  setUserId: (userId: number) => set({ userId }),
+  setNickname: (nickname: string) => set({ nickname }),
+  setEmail: (email: string) => set({ email }),
+  setUsername: (username: string) => set({ username }),
+
+}));
+//   setUserId: () => set((state) => ({})),
+//   setNickname: () => set((state) => ({})),
+//   setEmail: () => set((state) => ({})),
+//   setUsername: () => set((state) => ({})),
+// }));
+
+// const store = (set) => ({
+//   count: 0,
+//   upCount: () =>
+//     set((state) => ({
+//       count: state.count + 1,
+//     })),
+//   downCount: () =>
+//     set((state) => ({
+//       count: state.count - 1,
+//     })),
+//   resetCount: () =>
+//     set({
+//       count: 0,
+//     }),
+// });


### PR DESCRIPTION
### ✨ 작업 내용
 - access Token Header에 담아서 보내기
 - access Token 으로 유저 정보 받기
 - 받은 유저 정보 props로 넘겨주기
 - 유저 nickName 수정하기
 - 폴더 경로 수정 및 정리
 - 로그인 시 nickpage가 아닌 이전 페이지로 이동
---

### ✨ 참고 사항
- accessToken 관련 zustand 코드는 삭제 예정. (#15 참고)

---

### ⏰ 현재 버그
- 내상점에서 로그인 진행 시 로그인 완료할때 빈화면이 나오는 버그 발견
- 다시 시도할때는 정상적으로 동작해서 처음에만 발생하는지, 계속 발생하는지 알 수 없음..
---

### ✏ Git Close
